### PR TITLE
Fixed typo in Makefile.frag

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -8,7 +8,7 @@ install-phpdbg: $(BUILD_BINARY)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/log
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)/run
-	@$(INSTALL) -m 0755 $(BUILD_BINARY) $(INSTALL_ROOT)$(sbindir)/$(program_prefix)phpdbg$(program_suffix)$(EXEEXT)
+	@$(INSTALL) -m 0755 $(BUILD_BINARY) $(INSTALL_ROOT)$(bindir)/$(program_prefix)phpdbg$(program_suffix)$(EXEEXT)
 
 clean-phpdbg:
 	@echo "Cleaning phpdbg object files ..."


### PR DESCRIPTION
I think there is a typo in Makefile.frag ... at least either one is wrong and i assume you want to install the binary in 'bin/' rather than 'sbin/'?
