### PR TITLE
Remove phpdbg_help_header() output, too verbose

### DIFF
--- a/phpdbg_help.h
+++ b/phpdbg_help.h
@@ -85,8 +85,8 @@ static const phpdbg_command_t phpdbg_help_commands[] = {
 };
 
 #define phpdbg_help_header() \
-	phpdbg_notice("Welcome to phpdbg, the interactive PHP debugger, v%s", PHPDBG_VERSION);
+	NULL;
 #define phpdbg_help_footer() \
-	phpdbg_notice("Please report bugs to <%s>", PHPDBG_ISSUES);
+	phpdbg_notice("Version v%s; please report bugs to <%s>", PHPDBG_VERSION, PHPDBG_ISSUES);
 
 #endif /* PHPDBG_HELP_H */


### PR DESCRIPTION
Hello :-),

Each time we type `help …`, the `[Welcome to phpdbg, the interactive PHP debugger, v%s]` message is printed. I think this is too verbose. This message is printed when we start the REPL, no need to print it each time we ask some help.

After a short discussion on IRC, it seems the header is printed just to get the version number. Thus, I propose this patch to simplify it a bit:
- the `phpdbg_help_header` macro unfolds to `NULL`, in this way, we didn't break the existing code and allow the reuse of this macro,
- the `phpdbg_help_footer` macro now includes the version number.

Also, I am planning to _(i)_ add the `help version` command, _(ii)_ expose the phpdbg version through a PHP constant (maybe `PHPDBG_VERSION_ID`, to be consistent with [`PHP_VERSION_ID`](http://php.net/reserved.constants#constant.php-version-id), _(iii)_ add a `phpdbg` option to get the version directly (`-v` is already taken to enable oplog output, maybe `-V` could be a good candidate).

Thoughts?
