### PR TITLE
Fix phpdbg.1 man page installation when build != src directory

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -28,7 +28,7 @@ install-phpdbg: $(BUILD_BINARY)
 	@$(INSTALL) -m 0755 $(BUILD_BINARY) $(INSTALL_ROOT)$(bindir)/$(program_prefix)phpdbg$(program_suffix)$(EXEEXT)
 	@echo "Installing phpdbg man page:       $(INSTALL_ROOT)$(mandir)/man1/"
 	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
-	@$(INSTALL_DATA) sapi/phpdbg/phpdbg.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phpdbg$(program_suffix).1
+	@$(INSTALL_DATA) $(srcdir)/phpdbg.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phpdbg$(program_suffix).1
 
 clean-phpdbg:
 	@echo "Cleaning phpdbg object files ..."


### PR DESCRIPTION
Some PHP compilation methods (e.g. Redhat PHP rpms) make SAPI's build a clean directory. The addition of the phpdbg.1 man page breaks this method, as it's assuming the build directory is the source directory.

This affects a build I'm creating for PHP 5.6.0RC2
https://github.com/webtatic-rpms/php56w/blob/master/php56.spec#L1344

This PR fixes the problem by forcing the Makefile to get the man page from the source directory.

an example I think recreates the problem:

```
cd /usr/src/php-src/sapi
git clone https://github.com/krakjoe/phpdbg
cd ../
./buildconf --force
mkdir ./build-phpdbg

pushd ./build-phpdbg
ln -s ../configure
./configure --enable-phpdbg
popd

make -C build-phpdbg -j8
make -C build-phpdbg install-phpdbg
```
